### PR TITLE
changed write functions from 'ascii' to 'utf-8'

### DIFF
--- a/autocompletion/suggestions/generate_fake_bpy.py
+++ b/autocompletion/suggestions/generate_fake_bpy.py
@@ -47,7 +47,7 @@ def generate_fake_bpy():
 
 def create_init():
     path = os.path.join(directory, "__init__.py")
-    file = open(path, "w+")
+    file = open(path, "w+", encoding='utf-8')
     file.write(init_content)
     file.close()
 
@@ -248,7 +248,7 @@ def get_property_declaration(property):
 
 def write_code_file(name, code):
     path = os.path.join(private_path, name.lower() + ".py")
-    file = open(path, "w+")
+    file = open(path, "w+", encoding='utf-8')
     file.write(code)
     file.close()
 


### PR DESCRIPTION
Wasn't able to run create/regenerate faked bpy module because of out of ascii range exception. This fixed it (on macOS Sierra 10.12.6, didn't test on Windows but should work)